### PR TITLE
Bnd pax exam

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An implementation of [Apache Felix tutorials](http://felix.apache.org/documentation/tutorials-examples-and-presentations/apache-felix-osgi-tutorial.html).
 
-It has been updated to include Maven based projects for each of the samples.
+It has been updated to include Maven based projects for each of the samples, and is configured to use the [bnd-maven-plugin](https://github.com/bndtools/bnd/tree/master/maven/bnd-maven-plugin).
 
 **Note** that Example 8 doesn't currently work with Maven after trying to bring it up to speed.
 

--- a/mavenised/example1/bnd.bnd
+++ b/mavenised/example1/bnd.bnd
@@ -1,0 +1,2 @@
+Bundle-Activator: tutorial.example1.Activator
+Bundle-Description: A bundle that displays messages at startup and when service events occur

--- a/mavenised/example1/pom.xml
+++ b/mavenised/example1/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>felix.tutorial</groupId>
   <artifactId>example1</artifactId>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
   <version>1.0-SNAPSHOT</version>
 
   <name>Service Listener Example</name>
@@ -38,30 +38,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven_compiler.version}</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>${maven_bundle.version}</version>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Export-Package>
-            </Export-Package>
-            <Private-Package>
-              tutorial.example1
-            </Private-Package>
-            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-            <Bundle-Activator>
-              tutorial.example1.Activator
-            </Bundle-Activator>
-          </instructions>
-        </configuration>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/mavenised/example2.service/bnd.bnd
+++ b/mavenised/example2.service/bnd.bnd
@@ -1,0 +1,1 @@
+Export-Package: tutorial.example2.service

--- a/mavenised/example2.service/pom.xml
+++ b/mavenised/example2.service/pom.xml
@@ -11,7 +11,7 @@
   <groupId>felix.tutorial</groupId>
   <artifactId>example2.service</artifactId>
   <version>1.0-SNAPSHOT</version>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <name>English dictionary API</name>
   <url>http://maven.apache.org</url>
@@ -38,25 +38,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven_compiler.version}</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>${maven_bundle.version}</version>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Export-Package>
-              tutorial.example2.service
-            </Export-Package>
-            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-          </instructions>
-        </configuration>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/mavenised/example2/bnd.bnd
+++ b/mavenised/example2/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Activator: tutorial.example2.Activator
+Bundle-Description: A bundle that registers an English dictionary service
+Export-Package: tutorial.example2

--- a/mavenised/example2/pom.xml
+++ b/mavenised/example2/pom.xml
@@ -11,7 +11,7 @@
   <groupId>felix.tutorial</groupId>
   <artifactId>example2</artifactId>
   <version>1.0-SNAPSHOT</version>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <name>English dictionary</name>
   <url>http://maven.apache.org</url>
@@ -43,28 +43,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven_compiler.version}</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>${maven_bundle.version}</version>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Private-Package>
-              tutorial.example2
-            </Private-Package>
-            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-            <Bundle-Activator>
-              tutorial.example2.Activator
-            </Bundle-Activator>
-          </instructions>
-        </configuration>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/mavenised/example2/pom.xml
+++ b/mavenised/example2/pom.xml
@@ -31,12 +31,6 @@
       <artifactId>example2.service</artifactId>
       <version>1.0-SNAPSHOT</version>
     </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/mavenised/example2b/bnd.bnd
+++ b/mavenised/example2b/bnd.bnd
@@ -1,0 +1,2 @@
+Bundle-Activator: tutorial.example2b.Activator
+Export-Package: tutorial.example2b

--- a/mavenised/example2b/pom.xml
+++ b/mavenised/example2b/pom.xml
@@ -11,7 +11,7 @@
   <groupId>felix.tutorial</groupId>
   <artifactId>example2b</artifactId>
   <version>1.0-SNAPSHOT</version>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <name>French dictionary</name>
   <url>http://maven.apache.org</url>
@@ -43,28 +43,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven_compiler.version}</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>${maven_bundle.version}</version>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Private-Package>
-              tutorial.example2b
-            </Private-Package>
-            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-            <Bundle-Activator>
-              tutorial.example2b.Activator
-            </Bundle-Activator>
-          </instructions>
-        </configuration>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/mavenised/example3/bnd.bnd
+++ b/mavenised/example3/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Activator: tutorial.example3.Activator
+Bundle-Description: A bundle that uses the dictionary service if it finds it at startup
+Export-Package: tutorial.example3

--- a/mavenised/example3/pom.xml
+++ b/mavenised/example3/pom.xml
@@ -11,7 +11,7 @@
   <groupId>felix.tutorial</groupId>
   <artifactId>example3</artifactId>
   <version>1.0-SNAPSHOT</version>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <name>Dictionary client</name>
   <url>http://maven.apache.org</url>
@@ -43,30 +43,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven_compiler.version}</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>${maven_bundle.version}</version>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Export-Package>
-            </Export-Package>
-            <Private-Package>
-              tutorial.example3
-            </Private-Package>
-            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-            <Bundle-Activator>
-              tutorial.example3.Activator
-            </Bundle-Activator>
-          </instructions>
-        </configuration>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/mavenised/example4/bnd.bnd
+++ b/mavenised/example4/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Activator: tutorial.example4.Activator
+Bundle-Description: A bundle that uses the dictionary service whenever it becomes available
+Export-Package: tutorial.example4

--- a/mavenised/example4/pom.xml
+++ b/mavenised/example4/pom.xml
@@ -11,7 +11,7 @@
   <groupId>felix.tutorial</groupId>
   <artifactId>example4</artifactId>
   <version>1.0-SNAPSHOT</version>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <name>Dynamic dictionary client</name>
   <url>http://maven.apache.org</url>
@@ -43,28 +43,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven_compiler.version}</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>${maven_bundle.version}</version>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Private-Package>
-              tutorial.example4
-            </Private-Package>
-            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-            <Bundle-Activator>
-              tutorial.example4.Activator
-            </Bundle-Activator>
-          </instructions>
-        </configuration>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/mavenised/example5/bnd.bnd
+++ b/mavenised/example5/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Activator: tutorial.example5.Activator
+Bundle-Description: A dictinoary client using the Service Tracker
+Export-Package: tutorial.example5

--- a/mavenised/example5/pom.xml
+++ b/mavenised/example5/pom.xml
@@ -11,7 +11,7 @@
   <groupId>felix.tutorial</groupId>
   <artifactId>example5</artifactId>
   <version>1.0-SNAPSHOT</version>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <name>Service Tracker-based dictionary client</name>
   <url>http://maven.apache.org</url>
@@ -48,28 +48,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven_compiler.version}</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>${maven_bundle.version}</version>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Private-Package>
-              tutorial.example5
-            </Private-Package>
-            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-            <Bundle-Activator>
-              tutorial.example5.Activator
-            </Bundle-Activator>
-          </instructions>
-        </configuration>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/mavenised/example6.service/bnd.bnd
+++ b/mavenised/example6.service/bnd.bnd
@@ -1,0 +1,2 @@
+Bundle-Description: A bundle that describes a Spell Checker API
+Export-Package: tutorial.example6.service

--- a/mavenised/example6.service/pom.xml
+++ b/mavenised/example6.service/pom.xml
@@ -11,7 +11,7 @@
   <groupId>felix.tutorial</groupId>
   <artifactId>example6.service</artifactId>
   <version>1.0-SNAPSHOT</version>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <name>Spell checker service API</name>
   <url>http://maven.apache.org</url>
@@ -48,25 +48,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven_compiler.version}</version>
-        <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
-        </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.5.3</version>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Export-Package>
-              tutorial.example6.service
-            </Export-Package>
-            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-          </instructions>
-        </configuration>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/mavenised/example6/bnd.bnd
+++ b/mavenised/example6/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Activator: tutorial.example6.Activator
+Bundle-Description: A bundle that implements a simple spell checker service
+Export-Package: tutorial.example6

--- a/mavenised/example6/pom.xml
+++ b/mavenised/example6/pom.xml
@@ -11,7 +11,7 @@
   <groupId>felix.tutorial</groupId>
   <artifactId>example6</artifactId>
   <version>1.0-SNAPSHOT</version>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <name>Spell checker service</name>
   <url>http://maven.apache.org</url>
@@ -48,28 +48,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven_compiler.version}</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>${maven_bundle.version}</version>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Private-Package>
-              tutorial.example6
-            </Private-Package>
-            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-            <Bundle-Activator>
-              tutorial.example6.Activator
-            </Bundle-Activator>
-          </instructions>
-        </configuration>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/mavenised/example7/bnd.bnd
+++ b/mavenised/example7/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Activator: tutorial.example7.Activator
+Bundle-Description: A bundle that uses the Spell Checker service
+Export-Package: tutorial.example7

--- a/mavenised/example7/pom.xml
+++ b/mavenised/example7/pom.xml
@@ -12,7 +12,7 @@
   </parent>
 
   <artifactId>example7</artifactId>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
   <version>1.0-SNAPSHOT</version>
 
   <name>Spell checker client</name>
@@ -43,28 +43,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven_compiler.version}</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>${maven_bundle.version}</version>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Private-Package>
-              tutorial.example7
-            </Private-Package>
-            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-            <Bundle-Activator>
-              tutorial.example7.Activator
-            </Bundle-Activator>
-          </instructions>
-        </configuration>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/mavenised/example9/bnd.bnd
+++ b/mavenised/example9/bnd.bnd
@@ -1,0 +1,2 @@
+Bundle-Description: A bundle that contains a Declarative Services Spell Checker Component
+Export-Package: tutorial.example9

--- a/mavenised/example9/pom.xml
+++ b/mavenised/example9/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>example9</artifactId>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
   <version>1.0-SNAPSHOT</version>
 
   <name>Spell Checker Service using Declarative Services</name>
@@ -48,25 +48,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven_compiler.version}</version>
-        <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
-        </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <version>${maven_bundle.version}</version>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Private-Package>
-              tutorial.example9
-            </Private-Package>
-            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-          </instructions>
-        </configuration>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/mavenised/it/pom.xml
+++ b/mavenised/it/pom.xml
@@ -1,0 +1,235 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <parent>
+    <groupId>felix.tutorial</groupId>	
+    <artifactId>all-examples</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>felix.tutorial</groupId>
+  <artifactId>it</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Integration tests</name>
+  <url>http://maven.apache.org</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+
+    <!-- Test dependencies ... -->
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.core</artifactId>
+      <version>${osgi_core.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+      <version>1.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.compendium</artifactId>
+      <version>${osgi_compendium.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>felix.tutorial</groupId>
+      <artifactId>example2.service</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>felix.tutorial</groupId>
+      <artifactId>example6.service</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+    <!-- English dictionary test -->
+    <dependency>
+      <groupId>felix.tutorial</groupId>
+      <artifactId>example2</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+    <!-- French dictionary test -->
+    <dependency>
+      <groupId>felix.tutorial</groupId>
+      <artifactId>example2b</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+    <!-- Spell checker test, with Components -->
+    <dependency>
+      <groupId>felix.tutorial</groupId>
+      <artifactId>example9</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+
+    <!-- Test framework dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.framework</artifactId>
+      <version>${felix_framework.version}</version>
+      <scope>test</scope>
+    </dependency>
+<!--    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.framework</artifactId>
+      <version>${felix_framework.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.framework</artifactId>
+      <version>${felix_framework.version}</version>
+      <scope>test</scope>
+    </dependency> -->
+
+    <dependency>
+      <groupId>org.ops4j.pax.url</groupId>
+      <artifactId>pax-url-link</artifactId>
+      <version>${pax_url.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.url</groupId>
+      <artifactId>pax-url-classpath</artifactId>
+      <version>${pax_url.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+<!--    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-container-forked</artifactId>
+      <version>${pax_exam.version}</version>
+      <scope>test</scope>
+    </dependency> -->
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-container-native</artifactId>
+      <version>${pax_exam.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-junit4</artifactId>
+      <version>${pax_exam.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-link-assembly</artifactId>
+      <version>${pax_exam.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam</artifactId>
+      <version>${pax_exam.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.url</groupId>
+      <artifactId>pax-url-aether</artifactId>
+      <version>${pax_url.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <version>${logback.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
+      <scope>test</scope>
+    </dependency>
+<!--    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.6.6</version>
+      <scope>test</scope>
+    </dependency> -->
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>**/*.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <archive>
+            <manifestFile>src/test/resources/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.servicemix.tooling</groupId>
+        <artifactId>depends-maven-plugin</artifactId>
+        <version>1.4.0</version>
+        <executions>
+          <execution>
+            <id>generate-depends-file</id>
+            <goals>
+              <goal>generate-depends-file</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Single module Pax Exam config http://veithen.github.io/alta/examples/pax-exam-single-module.html -->
+      <!-- Separate integration test modules http://veithen.github.io/alta/examples/pax-exam.html -->
+      <plugin>
+        <groupId>com.github.veithen.alta</groupId>
+        <artifactId>alta-maven-plugin</artifactId>
+        <version>${alta.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate-test-resources</goal>
+            </goals>
+            <configuration>
+              <name>%bundle.symbolicName%.link</name>
+              <value>%url%</value>
+              <dependencySet>
+                <scope>test</scope>
+              </dependencySet>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/mavenised/it/src/test/java/tutorial/Example2Both.java
+++ b/mavenised/it/src/test/java/tutorial/Example2Both.java
@@ -1,0 +1,85 @@
+package tutorial;
+
+import static org.junit.Assert.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
+import javax.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.options.MavenArtifactProvisionOption;
+import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
+import org.ops4j.pax.exam.options.MavenUrlReference;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.util.tracker.ServiceTracker;
+
+import tutorial.example2.service.DictionaryService;
+
+@RunWith(PaxExam.class)
+public class Example2Both
+{
+  @Inject
+  private BundleContext bundleContext;
+
+  private List< DictionaryService > dictService;
+
+  @Configuration
+  public static Option[] configuration()
+  {
+    // http://veithen.github.io/alta/examples/pax-exam.html
+   return options( cleanCaches( true ), junitBundles(), 
+     url( "link:classpath:example2.service.link" ),
+     url( "link:classpath:example2b.link" ),
+     url( "link:classpath:example2.link" )
+   );
+  }
+
+  @Before
+  public void setup() throws Exception
+  {
+    dictService = new ArrayList<>();
+    ServiceTracker tracker = new ServiceTracker( bundleContext, DictionaryService.class.getName(), null );
+    tracker.open();
+    tracker.waitForService( 5000 );
+    ServiceReference[] services = tracker.getServiceReferences();
+    for( ServiceReference o : services )
+    {
+      dictService.add( (DictionaryService)tracker.getService( o ) );
+    }    
+    tracker.close();
+  }
+
+  private boolean checkWord( String word )
+  {
+    for( DictionaryService d : dictService )
+    {
+      if( d.checkWord( word ) ) return true;
+    }
+    return false;
+  }
+
+  @Test
+  public void wordInListEnglish()
+  {
+    assertTrue( "The word was not spelled correctly", checkWord( "welcome" ) );
+  }
+
+  @Test
+  public void wordInListFrench()
+  {
+    assertTrue( "The word was not spelled correctly", checkWord( "bienvenue" ) );
+  }
+
+  @Test
+  public void wordNotInList()
+  {
+    assertFalse( "The word was spelled correctly", checkWord( "welocme" ) );
+  }
+}

--- a/mavenised/it/src/test/java/tutorial/Example2English.java
+++ b/mavenised/it/src/test/java/tutorial/Example2English.java
@@ -1,0 +1,53 @@
+package tutorial;
+
+import static org.junit.Assert.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.options.MavenArtifactProvisionOption;
+import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
+import org.ops4j.pax.exam.options.MavenUrlReference;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.util.tracker.ServiceTracker;
+
+import tutorial.example2.service.DictionaryService;
+
+@RunWith(PaxExam.class)
+public class Example2English
+{
+  @Inject
+  private BundleContext bundleContext;
+
+  @Inject
+  private DictionaryService dictService;
+
+  @Configuration
+  public static Option[] configuration()
+  {
+    // http://veithen.github.io/alta/examples/pax-exam.html
+   return options( cleanCaches( true ), junitBundles(), 
+     url( "link:classpath:example2.service.link" ),
+     url( "link:classpath:example2.link" )
+   );
+  }
+
+  @Test
+  public void wordInList()
+  {
+    assertTrue( "The word was not spelled correctly", dictService.checkWord( "welcome" ) );
+  }
+
+  @Test
+  public void wordNotInList()
+  {
+    assertFalse( "The word was spelled correctly", dictService.checkWord( "welocme" ) );
+  }
+}

--- a/mavenised/it/src/test/java/tutorial/Example2French.java
+++ b/mavenised/it/src/test/java/tutorial/Example2French.java
@@ -1,0 +1,53 @@
+package tutorial;
+
+import static org.junit.Assert.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.options.MavenArtifactProvisionOption;
+import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
+import org.ops4j.pax.exam.options.MavenUrlReference;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.util.tracker.ServiceTracker;
+
+import tutorial.example2.service.DictionaryService;
+
+@RunWith(PaxExam.class)
+public class Example2French
+{
+  @Inject
+  private BundleContext bundleContext;
+
+  @Inject
+  private DictionaryService dictService;
+
+  @Configuration
+  public static Option[] configuration()
+  {
+    // http://veithen.github.io/alta/examples/pax-exam.html
+   return options( cleanCaches( true ), junitBundles(), 
+     url( "link:classpath:example2.service.link" ),
+     url( "link:classpath:example2b.link" )
+   );
+  }
+
+  @Test
+  public void wordInList()
+  {
+    assertTrue( "The word was not spelled correctly", dictService.checkWord( "bienvenue" ) );
+  }
+
+  @Test
+  public void wordNotInList()
+  {
+    assertFalse( "The word was spelled correctly", dictService.checkWord( "beinvenue" ) );
+  }
+}

--- a/mavenised/it/src/test/java/tutorial/Example9Both.java
+++ b/mavenised/it/src/test/java/tutorial/Example9Both.java
@@ -1,0 +1,72 @@
+package tutorial;
+
+import static org.junit.Assert.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.options.MavenArtifactProvisionOption;
+import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
+import org.ops4j.pax.exam.options.MavenUrlReference;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.util.tracker.ServiceTracker;
+
+import tutorial.example6.service.SpellChecker;
+
+@RunWith(PaxExam.class)
+public class Example9Both
+{
+  @Inject
+  private BundleContext bundleContext;
+
+  @Inject
+  private SpellChecker spellService;
+
+  @Configuration
+  public static Option[] configuration()
+  {
+    // http://veithen.github.io/alta/examples/pax-exam.html
+   return options( cleanCaches( true ), junitBundles(), 
+     mavenBundle( "org.apache.felix", "org.apache.felix.scr", "2.1.0" ),
+     mavenBundle( "org.apache.felix", "org.apache.felix.scr.annotations", "1.12.0" ),
+     url( "link:classpath:example2.service.link" ),
+     url( "link:classpath:example2.link" ),
+     url( "link:classpath:example2b.link" ),
+     url( "link:classpath:example6.service.link" ),
+     url( "link:classpath:example9.link" )
+   );
+  }
+
+  @Test
+  public void nullMeansPass()
+  {
+    assertNull( "A null string should pass", spellService.check( null ) );
+  }
+
+  @Test
+  public void emptyMeansPass()
+  {
+    assertNull( "An empty string should pass", spellService.check( "" ) );
+  }
+
+  @Test
+  public void goodPhrase()
+  {
+    assertNull( "The phrase is spelled correctly", spellService.check( "welcome au osgi tutoriel" ) );
+  }
+
+  @Test
+  public void oneBadWord()
+  {
+    String [] badWords = spellService.check( "welocme au osgi tutoriel" );
+    assertNotNull( "The phrase has no word errors", badWords );
+    assertEquals( "Only one word should be bad", badWords.length, 1 );
+  }
+}

--- a/mavenised/it/src/test/java/tutorial/Example9English.java
+++ b/mavenised/it/src/test/java/tutorial/Example9English.java
@@ -1,0 +1,71 @@
+package tutorial;
+
+import static org.junit.Assert.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.options.MavenArtifactProvisionOption;
+import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
+import org.ops4j.pax.exam.options.MavenUrlReference;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.util.tracker.ServiceTracker;
+
+import tutorial.example6.service.SpellChecker;
+
+@RunWith(PaxExam.class)
+public class Example9English
+{
+  @Inject
+  private BundleContext bundleContext;
+
+  @Inject
+  private SpellChecker spellService;
+
+  @Configuration
+  public static Option[] configuration()
+  {
+    // http://veithen.github.io/alta/examples/pax-exam.html
+   return options( cleanCaches( true ), junitBundles(), 
+     mavenBundle( "org.apache.felix", "org.apache.felix.scr", "2.1.0" ),
+     mavenBundle( "org.apache.felix", "org.apache.felix.scr.annotations", "1.12.0" ),
+     url( "link:classpath:example2.service.link" ),
+     url( "link:classpath:example2.link" ),
+     url( "link:classpath:example6.service.link" ),
+     url( "link:classpath:example9.link" )
+   );
+  }
+
+  @Test
+  public void nullMeansPass()
+  {
+    assertNull( "A null string should pass", spellService.check( null ) );
+  }
+
+  @Test
+  public void emptyMeansPass()
+  {
+    assertNull( "An empty string should pass", spellService.check( "" ) );
+  }
+
+  @Test
+  public void goodPhrase()
+  {
+    assertNull( "The phrase is spelled correctly", spellService.check( "welcome to the osgi tutorial" ) );
+  }
+
+  @Test
+  public void oneBadWord()
+  {
+    String [] badWords = spellService.check( "welocme to the osgi tutorial" );
+    assertNotNull( "The phrase has no word errors", badWords );
+    assertEquals( "Only one word should be bad", badWords.length, 1 );
+  }
+}

--- a/mavenised/it/src/test/java/tutorial/Example9French.java
+++ b/mavenised/it/src/test/java/tutorial/Example9French.java
@@ -1,0 +1,71 @@
+package tutorial;
+
+import static org.junit.Assert.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.options.MavenArtifactProvisionOption;
+import org.ops4j.pax.exam.options.MavenArtifactUrlReference;
+import org.ops4j.pax.exam.options.MavenUrlReference;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.util.tracker.ServiceTracker;
+
+import tutorial.example6.service.SpellChecker;
+
+@RunWith(PaxExam.class)
+public class Example9French
+{
+  @Inject
+  private BundleContext bundleContext;
+
+  @Inject
+  private SpellChecker spellService;
+
+  @Configuration
+  public static Option[] configuration()
+  {
+    // http://veithen.github.io/alta/examples/pax-exam.html
+   return options( cleanCaches( true ), junitBundles(), 
+     mavenBundle( "org.apache.felix", "org.apache.felix.scr", "2.1.0" ),
+     mavenBundle( "org.apache.felix", "org.apache.felix.scr.annotations", "1.12.0" ),
+     url( "link:classpath:example2.service.link" ),
+     url( "link:classpath:example2b.link" ),
+     url( "link:classpath:example6.service.link" ),
+     url( "link:classpath:example9.link" )
+   );
+  }
+
+  @Test
+  public void nullMeansPass()
+  {
+    assertNull( "A null string should pass", spellService.check( null ) );
+  }
+
+  @Test
+  public void emptyMeansPass()
+  {
+    assertNull( "An empty string should pass", spellService.check( "" ) );
+  }
+
+  @Test
+  public void goodPhrase()
+  {
+    assertNull( "The phrase is spelled correctly", spellService.check( "bienvenue au tutoriel osgi" ) );
+  }
+
+  @Test
+  public void oneBadWord()
+  {
+    String [] badWords = spellService.check( "beinvenue au tutoriel osgi" );
+    assertNotNull( "The phrase has no word errors", badWords );
+    assertEquals( "Only one word should be bad", badWords.length, 1 );
+  }
+}

--- a/mavenised/it/src/test/resources/META-INF/manifest.mf
+++ b/mavenised/it/src/test/resources/META-INF/manifest.mf
@@ -1,0 +1,1 @@
+Manifest-Version: 1.0

--- a/mavenised/pom.xml
+++ b/mavenised/pom.xml
@@ -15,10 +15,15 @@
     <maven_jar.version>3.1.0</maven_jar.version>
     <maven_source.version>3.0.1</maven_source.version>
     <maven_javadoc.version>3.0.1</maven_javadoc.version>
-    <maven_surefire.version>2.21.0</maven_surefire.version>
+    <maven_surefire.version>2.22.0</maven_surefire.version>
     <osgi_core.version>5.0.0</osgi_core.version>
     <osgi_compendium.version>5.0.0</osgi_compendium.version>
     <felix_framework.version>5.6.10</felix_framework.version>
+    <pax_exam.version>4.11.0</pax_exam.version>
+    <pax_url.version>2.5.4</pax_url.version>
+    <javax_inject.version>1</javax_inject.version>
+    <logback.version>1.2.3</logback.version>
+    <alta.version>0.6.2</alta.version>
   </properties>
   <modules>
     <module>example1</module>
@@ -33,6 +38,7 @@
     <module>example7</module>
 <!--    <module>example8</module> -->
     <module>example9</module>
+    <module>it</module>
   </modules>
   <build>
     <pluginManagement>
@@ -67,6 +73,11 @@
               <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
             </archive>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven_surefire.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/mavenised/pom.xml
+++ b/mavenised/pom.xml
@@ -34,4 +34,41 @@
 <!--    <module>example8</module> -->
     <module>example9</module>
   </modules>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${maven_compiler.version}</version>
+          <configuration>
+            <source>${java.version}</source>
+            <target>${java.version}</target>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>biz.aQute.bnd</groupId>
+          <artifactId>bnd-maven-plugin</artifactId>
+          <version>${bnd_maven.version}</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>bnd-process</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>${maven_jar.version}</version>
+          <configuration>
+            <archive>
+              <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+            </archive>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>


### PR DESCRIPTION
Migrates to Java 8, latest version of Maven, adds some more examples, uses the bndtools plugin, and creates some basic tests for Examples 2 and 9 with PAX Exam.